### PR TITLE
Fix/module path

### DIFF
--- a/example/inspection/inspection.d
+++ b/example/inspection/inspection.d
@@ -80,7 +80,7 @@ int main() {
       libusb_free_config_descriptor(dev_cfg);
     }
   }
-  libusb_free_device_list(devlist, devcount);
+  libusb_free_device_list(devlist, cast(int)devcount);
 
   libusb_exit(ctx);
   

--- a/src/libusb/consts.d
+++ b/src/libusb/consts.d
@@ -14,9 +14,9 @@
  *
  */
 
-module consts;
+module libusb.consts;
 
-import structs : libusb_control_setup;
+import libusb.structs : libusb_control_setup;
 
 /** LIBUSB API Version */
 const LIBUSBX_API_VERSION =  0x01000102;

--- a/src/libusb/enums.d
+++ b/src/libusb/enums.d
@@ -14,7 +14,7 @@
  *
  */
 
-module enums;
+module libusb.enums;
 
 alias libusb_hotplug_flag = LIBUSB_HOTPLUG_ENUM;
 alias libusb_hotplug_event = LIBUSB_HOTPLUG_EVENTS;

--- a/src/libusb/funcs.d
+++ b/src/libusb/funcs.d
@@ -14,11 +14,11 @@
  *
  */
 
-module funcs;
+module libusb.funcs;
 
-import consts;
-import enums;
-import structs;
+import libusb.consts;
+import libusb.enums;
+import libusb.structs;
 import core.stdc.limits : INT_MAX;
 
 version( Windows ) {

--- a/src/libusb/package.d
+++ b/src/libusb/package.d
@@ -35,10 +35,10 @@ import std.traits;
 import std.typetuple : NoDuplicates;
 
 public {
-  import consts;
-  import enums;
-  import structs;
-  import funcs;
+  import libusb.consts;
+  import libusb.enums;
+  import libusb.structs;
+  import libusb.funcs;
 }
 
 /* Total number of error codes in enum libusb_error */

--- a/src/libusb/structs.d
+++ b/src/libusb/structs.d
@@ -14,9 +14,9 @@
  *
  */
 
-module structs;
+module libusb.structs;
 
-import enums;
+import libusb.enums;
 
 extern (C):
 


### PR DESCRIPTION
Partial paths were causing the builds to break, event though the
examples would still compile.